### PR TITLE
MNRL 1.0 compatibility update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
     - Boost >= 1.57 (i.e., ` sudo apt-get install libboost-all-dev`)
 - MNRL 1.0
 - `build-essential`
-- `sudo apt-get install ragel`
+- rage (i.e., `sudo apt-get install ragel`)
+- sqlite3 (i.e., `sudo apt-get install -y libsqlite3-dev`)
 
 ## Building
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 - Hyperscan 4.4 source
     - Boost >= 1.57
 - MNRL 1.0
+- `build-essential`
 
 ## Building
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,26 @@ make
 
 ```bash
 git clone https://github.com/kevinaangstadt/mnrl
-cd mnrl/C++
+cd mnrl
+git checkout v1.0
+cd C++
+git submodule init
+git submodule update   
+cd lib/valijson
+git checkout v0.3
+cd ../..
+```
+
+edit the Makefile and change 
+```
+JSON = ./lib/valijson/thirdparty/nlohmann-json-1.1.0
+```
+with
+```
+JSON = ./lib/valijson/thirdparty/nlohmann-json-3.1.2
+```
+then
+```
 make
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 - `build-essential`
 - rage (i.e., `sudo apt-get install ragel`)
 - sqlite3 (i.e., `sudo apt-get install -y libsqlite3-dev`)
+- pkg-config (i.e., `sudo apt-get install pkg-config`)
 
 ## Building
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 - rage (i.e., `sudo apt-get install ragel`)
 - sqlite3 (i.e., `sudo apt-get install -y libsqlite3-dev`)
 - pkg-config (i.e., `sudo apt-get install pkg-config`)
+- nasm (i.e., `sudo apt-get -y install nasm`)
 
 ## Building
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
     - Boost >= 1.57 (i.e., ` sudo apt-get install libboost-all-dev`)
 - MNRL 1.0
 - `build-essential`
+- `sudo apt-get install ragel`
 
 ## Building
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 
 - cmake >= 2.6
 - Hyperscan 4.4 source
-    - Boost >= 1.57
+    - Boost >= 1.57 (i.e., ` sudo apt-get install libboost-all-dev`)
 - MNRL 1.0
 - `build-essential`
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 - cmake >= 2.6
 - Hyperscan 4.4 source
     - Boost >= 1.57
-- MNRL
+- MNRL 1.0
 
 ## Building
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:


### PR DESCRIPTION
Hello,

This pull request should fix the MNRL 1.0 issue.

The problem was around MNRL submodules ( but for 1.0 version only)
Json11  is now archived and fixed, while valijson is now set to v0.3
The Makefile of MNRL has to be fixed in the way here suggested.

We tested on an ANMLZoo Fermi MNRL and it compiles.

Hope this help


@emanueledelsozzo, Davide