### PR TITLE
Tom

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 
 ## Required Packages
 
+- g++-5, gcc-5 !!(Newer versions of gcc/g++ currently aren't supported)!!
 - cmake >= 2.6
 - Hyperscan 4.4 source
     - Boost >= 1.57
@@ -15,6 +16,13 @@ using Hyperscan as a CPU back-end.  There is also support for compiling PCRE to 
 To successfully build `hscompile`, you must first build Hyperscan and the MNRL C++ API:
 
 ```bash
+git clone https://github.com/tjt7a/hscompile.git
+```
+
+```bash
+cd hscompile
+mkdir lib
+cd lib
 git clone https://github.com/01org/hyperscan
 cd hyperscan
 git checkout v4.4.1
@@ -25,7 +33,9 @@ make
 ```
 
 ```bash
+cd ..
 git clone https://github.com/kevinaangstadt/mnrl
+git checkout v1.0
 cd mnrl/C++
 make
 ```
@@ -33,10 +43,12 @@ make
 Next, clone the `hscompile` repository and create a build directory inside the repo.  Then, you can use `cmake` to generate a Makefile and build.  You must provide paths to Hyperscan (`HS_SOURCE_DIR`) and MNRL (`MNRL_SOURCE_DIR`), and you can override the default Hyperscan build path with `HS_BUILD_DIR`.
 
 ```bash
-git clone https://github.com/kevinaangstadt/hscompile
-cd hscompile
+cd .. 
 mkdir build
 cd build
-cmake -DHS_SOURCE_DIR=/path/to/hyperscan -DMNRL_SOURCE_DIR=/path/to/mnrl/C++ ..
+
+cmake -DCMAKE_CXX_COMPILER=g++-5 -DCMAKE_C_COMPILER=gcc-5 -DHS_SOURCE_DIR=/home/tjt7a/src/hscompile/lib/hyperscan -DMNRL_SOURCE_DIR=/home/tjt7a/src/hscompile/lib/mnrl/C++ ..
+
+
 make
 ```

--- a/src/hsrun.c
+++ b/src/hsrun.c
@@ -45,7 +45,7 @@ static int supportEventHandler(unsigned int id, unsigned long long from,
     
     unsigned int *support = (unsigned int *) ctx;
     
-    #pragma omp atomic
+    //#pragma omp atomic
     support[id]++;
     
     return 0;
@@ -351,7 +351,7 @@ int main(int argc, char *argv[]) {
         omp_set_dynamic(1);
         omp_set_num_threads(num_threads);
     }
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for ( int i=0; i<num_inputs*num_dbs; i++ ) {
         run_ctx ctx = contexts[i];
         


### PR DESCRIPTION
When using hscompile for runtime performance, it is important to run tests with a single thread and without the openmp runtime. This runtime introduces high variance in performance metrics.